### PR TITLE
Add 1Password CLI support with intelligent SSH signing workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,6 +34,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   direnv \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Install 1Password CLI
+RUN ARCH=$(dpkg --print-architecture) && \
+  curl -sSfo op.zip https://cache.agilebits.com/dist/1P/op2/pkg/v2.30.0/op_linux_${ARCH}_v2.30.0.zip && \
+  unzip -d /usr/local/bin op.zip && \
+  rm op.zip && \
+  chmod +x /usr/local/bin/op
+
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
   chown -R node:node /usr/local/share
@@ -221,12 +228,14 @@ COPY init-firewall.sh /usr/local/bin/
 COPY setup-git.sh /usr/local/bin/
 COPY create-limited-git-setup.sh /usr/local/bin/
 COPY setup-direnv.sh /usr/local/bin/
+COPY op-ssh-sign-wrapper.sh /usr/local/bin/
 COPY liquescent.omp.json /usr/local/share/
 USER root
 RUN chmod +x /usr/local/bin/init-firewall.sh && \
   chmod +x /usr/local/bin/setup-git.sh && \
   chmod +x /usr/local/bin/create-limited-git-setup.sh && \
   chmod +x /usr/local/bin/setup-direnv.sh && \
+  chmod +x /usr/local/bin/op-ssh-sign-wrapper.sh && \
   chmod 644 /usr/local/share/liquescent.omp.json && \
   echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall

--- a/.devcontainer/op-ssh-sign-wrapper.sh
+++ b/.devcontainer/op-ssh-sign-wrapper.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Wrapper script for git signing in devcontainer
+# Helps users authenticate with 1Password CLI or set up alternative signing methods
+
+setup_ssh_signing() {
+    echo ""
+    echo "🔐 Setting up SSH commit signing in the container..."
+    echo ""
+    
+    # Check for existing SSH keys
+    if [ -d "$HOME/.ssh" ] && [ "$(ls -A $HOME/.ssh/*.pub 2>/dev/null)" ]; then
+        echo "Found existing SSH public keys:"
+        echo ""
+        ls -1 $HOME/.ssh/*.pub 2>/dev/null | while read -r key; do
+            echo "  • $(basename "$key")"
+        done
+        echo ""
+        echo "Would you like to:"
+        echo "  1) Use an existing SSH key for signing"
+        echo "  2) Create a new SSH key for signing"
+        echo "  3) Disable commit signing for this repository"
+        echo "  4) Cancel"
+        echo ""
+        read -p "Select an option (1-4): " choice
+    else
+        echo "No SSH keys found in the container."
+        echo ""
+        echo "Would you like to:"
+        echo "  1) Create a new SSH key for signing"
+        echo "  2) Disable commit signing for this repository"
+        echo "  3) Cancel"
+        echo ""
+        read -p "Select an option (1-3): " choice
+        if [ "$choice" = "1" ]; then
+            choice="2"  # Map to create new key option
+        elif [ "$choice" = "2" ]; then
+            choice="3"  # Map to disable signing option
+        else
+            choice="4"  # Map to cancel option
+        fi
+    fi
+    
+    case $choice in
+        1)
+            # Use existing SSH key
+            echo ""
+            echo "Available SSH keys:"
+            select key_file in $HOME/.ssh/*.pub; do
+                if [ -n "$key_file" ]; then
+                    key_path="${key_file%.pub}"
+                    echo ""
+                    echo "Configuring git to use: $(basename "$key_path")"
+                    git config --global user.signingkey "$key_path"
+                    git config --global gpg.format ssh
+                    git config --global commit.gpgsign true
+                    
+                    echo ""
+                    echo "✅ Git configured to use SSH key for signing!"
+                    echo ""
+                    echo "📋 Add this public key to GitHub:"
+                    echo "   1. Go to https://github.com/settings/keys"
+                    echo "   2. Click 'New SSH key'"
+                    echo "   3. Select 'Signing Key' as the key type"
+                    echo "   4. Paste the following key:"
+                    echo ""
+                    cat "$key_file"
+                    echo ""
+                    echo "Press Enter to continue..."
+                    read
+                    break
+                fi
+            done
+            ;;
+        2)
+            # Create new SSH key
+            echo ""
+            read -p "Enter your email for the SSH key: " email
+            if [ -z "$email" ]; then
+                email="$(git config --global user.email || echo 'user@devcontainer')"
+            fi
+            
+            key_name="id_ed25519_signing"
+            key_path="$HOME/.ssh/$key_name"
+            
+            echo ""
+            echo "Creating new SSH signing key..."
+            ssh-keygen -t ed25519 -C "$email" -f "$key_path" -N ""
+            
+            if [ -f "$key_path" ]; then
+                git config --global user.signingkey "$key_path"
+                git config --global gpg.format ssh
+                git config --global commit.gpgsign true
+                
+                echo ""
+                echo "✅ New SSH key created and configured for signing!"
+                echo ""
+                echo "📋 Add this public key to GitHub:"
+                echo "   1. Go to https://github.com/settings/keys"
+                echo "   2. Click 'New SSH key'"
+                echo "   3. Select 'Signing Key' as the key type"
+                echo "   4. Paste the following key:"
+                echo ""
+                cat "${key_path}.pub"
+                echo ""
+                echo "Press Enter to continue..."
+                read
+            else
+                echo "❌ Failed to create SSH key"
+                exit 1
+            fi
+            ;;
+        3)
+            # Disable signing for this repository
+            echo ""
+            echo "Disabling commit signing for this repository..."
+            git config --local commit.gpgsign false
+            echo "✅ Commit signing disabled for this repository"
+            echo ""
+            echo "Note: You can re-enable it later with:"
+            echo "  git config --local commit.gpgsign true"
+            ;;
+        *)
+            echo "Cancelled."
+            exit 1
+            ;;
+    esac
+}
+
+# Check if we're trying to use 1Password for signing
+if [[ "$1" == "sign" ]]; then
+    # First, check if 1Password CLI is authenticated
+    if ! /usr/local/bin/op account list &>/dev/null; then
+        echo ""
+        echo "🔐 1Password CLI is not authenticated."
+        echo ""
+        echo "Would you like to:"
+        echo "  1) Sign in to 1Password CLI (recommended - use your existing SSH keys)"
+        echo "  2) Set up alternative SSH key signing"
+        echo "  3) Disable commit signing for this repository"
+        echo "  4) Cancel"
+        echo ""
+        read -p "Select an option (1-4): " choice
+        
+        case $choice in
+            1)
+                echo ""
+                echo "📝 Signing in to 1Password CLI..."
+                echo "   You'll need your 1Password account email and Secret Key"
+                echo ""
+                /usr/local/bin/op signin
+                
+                if /usr/local/bin/op account list &>/dev/null; then
+                    echo ""
+                    echo "✅ Successfully authenticated with 1Password!"
+                    echo "   Your SSH signing keys from 1Password are now available."
+                    
+                    # Now try to execute the sign command with 1Password CLI
+                    exec /usr/local/bin/op "$@"
+                else
+                    echo ""
+                    echo "❌ Authentication failed. Falling back to alternative methods..."
+                    setup_ssh_signing
+                fi
+                ;;
+            2)
+                setup_ssh_signing
+                ;;
+            3)
+                # Disable signing for this repository
+                echo ""
+                echo "Disabling commit signing for this repository..."
+                git config --local commit.gpgsign false
+                echo "✅ Commit signing disabled for this repository"
+                echo ""
+                echo "Note: You can re-enable it later with:"
+                echo "  git config --local commit.gpgsign true"
+                exit 1
+                ;;
+            *)
+                echo "Cancelled."
+                exit 1
+                ;;
+        esac
+    else
+        # 1Password CLI is authenticated, use it for signing
+        exec /usr/local/bin/op "$@"
+    fi
+    
+    # After setup, try to sign again with the new configuration
+    if [ "$(git config --get commit.gpgsign)" = "true" ] && [ "$(git config --get gpg.format)" = "ssh" ]; then
+        ssh_key=$(git config --get user.signingkey)
+        if [ -n "$ssh_key" ] && [ -f "$ssh_key" ]; then
+            # Use ssh-keygen for signing instead
+            shift  # Remove 'sign' argument
+            exec ssh-keygen -Y sign "$@"
+        fi
+    fi
+    
+    # If we get here, signing is disabled or failed
+    exit 1
+fi
+
+# If we get here, try to execute the actual op command
+# This will likely fail in a container, but we try anyway
+exec /usr/local/bin/op "$@"

--- a/.devcontainer/setup-git.sh
+++ b/.devcontainer/setup-git.sh
@@ -11,17 +11,24 @@ if [ -f "/workspace/.env" ]; then
     export $(cat /workspace/.env | grep -v '^#' | xargs)
 fi
 
+# Always copy host gitconfig if it exists (to have a writable version)
+# This is needed for the commit signing wrapper to modify git config
+if [ -f "/home/node/.gitconfig.host" ]; then
+    cp /home/node/.gitconfig.host /home/node/.gitconfig
+    echo "✅ Created writable .gitconfig from host"
+    
+    # Update the 1Password SSH program path from macOS to Linux
+    # Check if the git config uses 1Password for SSH signing
+    if grep -q "/Applications/1Password.app" /home/node/.gitconfig 2>/dev/null; then
+        # Replace macOS 1Password path with the wrapper script
+        sed -i 's|/Applications/1Password.app/Contents/MacOS/op-ssh-sign|/usr/local/bin/op-ssh-sign-wrapper.sh|g' /home/node/.gitconfig
+        echo "✅ Updated 1Password SSH signing path for Linux container"
+    fi
+fi
+
 # Check if we should use host git config
 if [ "${MOUNT_HOST_GIT_CONFIG}" = "true" ]; then
     echo "📂 Using host git configuration..."
-    
-    # Copy host gitconfig (so VS Code can add its credential helper)
-    if [ -f "/home/node/.gitconfig.host" ]; then
-        cp /home/node/.gitconfig.host /home/node/.gitconfig
-        echo "✅ Copied host .gitconfig (writable copy for VS Code)"
-    else
-        echo "⚠️  Host .gitconfig not found"
-    fi
     
     # Symlink SSH directory (read-only is fine for SSH keys)
     if [ -d "/home/node/.ssh-host" ]; then

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To use this devcontainer template, you'll need:
 - **Claude Code CLI** for AI-assisted development
 - **Git Delta** for enhanced git diff visualization
 - **GitHub CLI** for repository management
+- **1Password CLI** with commit signing support (graceful fallback in container)
 - **direnv** for automatic environment variable loading from `.env` files
 - **Node.js 20** with npm global package support
 - **Go 1.25.0** with GOPATH configured and module support
@@ -144,7 +145,17 @@ code /path/to/your/project
 Both options include:
 - **GitHub CLI**: Pre-installed and ready for authentication
 - **Git Delta**: Enhanced diff visualization
+- **1Password CLI**: For commit signing (with graceful fallback if desktop app unavailable)
 - **Configuration Verification**: Automatic validation on container start
+
+**Note on Commit Signing**: If you use 1Password for commit signing on your host, the container includes the 1Password CLI with an intelligent wrapper that will:
+- Prompt you to authenticate with `op signin` to use your existing 1Password SSH keys
+- Once authenticated, use the same SSH signing keys from your 1Password vault
+- Alternatively, guide you through setting up local SSH key signing
+- Help you create a new SSH signing key if needed
+- Provide instructions for adding keys to GitHub
+- Option to disable signing for the current repository
+The wrapper runs automatically on your first commit attempt and preserves your signing workflow
 
 ### VS Code Integration
 - Pre-configured extensions for JavaScript/TypeScript development


### PR DESCRIPTION
## Summary

This PR adds comprehensive 1Password CLI support to the devcontainer with an intelligent workflow for SSH commit signing:

• **1Password CLI v2.30.0** - Full CLI installation in container
• **Intelligent wrapper script** - Seamlessly handles SSH signing authentication
• **Automatic path conversion** - Replaces macOS 1Password paths with Linux equivalents
• **Graceful fallbacks** - Provides alternative SSH signing options when 1Password unavailable
• **Enhanced user experience** - Interactive prompts guide users through authentication and setup

## Key Features

**Automatic 1Password Integration:**
- Detects existing 1Password SSH signing configuration from host
- Automatically converts macOS paths to work in Linux container
- Preserves existing commit signing workflow

**Interactive Authentication Workflow:**
- Prompts users to authenticate with `op signin` on first commit
- Uses existing SSH keys from 1Password vault once authenticated
- No manual configuration required for existing 1Password users

**Comprehensive Fallback Options:**
- Create new SSH signing keys in container
- Use existing SSH keys from mounted directories
- Option to disable signing for specific repositories
- Clear instructions for adding keys to GitHub

**Technical Improvements:**
- Always creates writable gitconfig copy for dynamic modifications
- Intelligent wrapper replaces 1Password desktop app calls
- Preserves all existing functionality while adding new capabilities

## Test Plan

- [ ] Test with existing 1Password SSH signing setup
- [ ] Verify authentication prompt appears for unauthenticated users
- [ ] Test fallback SSH key creation workflow
- [ ] Confirm existing git configurations remain unchanged
- [ ] Validate commit signing works after authentication
- [ ] Test repository-specific signing disable option