### PR TITLE
Fix 1Password domain resolution in firewall script

### DIFF
--- a/docker-image/scripts/init-firewall.sh
+++ b/docker-image/scripts/init-firewall.sh
@@ -80,11 +80,11 @@ done
 # Based on: https://support.1password.com/ports-domains/
 echo "Configuring 1Password domains..."
 # Common 1Password subdomains across all regions (.com, .eu, .ca)
-onepassword_subdomains="1password my.1password app.1password api.1password events.1password b5n.1password"
-onepassword_tlds="com eu ca"
+onepassword_subdomains=("1password" "my.1password" "app.1password" "api.1password" "events.1password" "b5n.1password")
+onepassword_tlds=("com" "eu" "ca")
 
-for subdomain in $onepassword_subdomains; do
-    for tld in $onepassword_tlds; do
+for subdomain in "${onepassword_subdomains[@]}"; do
+    for tld in "${onepassword_tlds[@]}"; do
         domain="${subdomain}.${tld}"
         echo "Resolving $domain..."
         # Use timeout and don't fail if a regional domain doesn't exist


### PR DESCRIPTION
## Summary
Fixes the firewall script's 1Password domain resolution that was broken due to IFS (Internal Field Separator) configuration.

## Problem
The strict `IFS=$'\n\t'` setting at the top of the script was preventing proper iteration over space-separated strings. This caused the firewall script to concatenate all 1Password subdomains and TLDs into a single string instead of iterating through them individually.

### Symptoms:
- `op whoami` worked (cached auth check)
- `op vault list` hung indefinitely (needed network access)
- Firewall logs showed: `Resolving 1password my.1password app.1password api.1password events.1password b5n.1password.com eu ca...`
- The IP `34.199.143.37` for `my.1password.com` was not in the allowlist

## Solution
Changed from space-separated strings to bash arrays for the 1Password subdomain and TLD lists. Arrays work correctly regardless of IFS settings.

## Changes
- Convert `onepassword_subdomains` from string to array
- Convert `onepassword_tlds` from string to array  
- Update loop syntax to use array expansion `"${array[@]}"`

## Testing
Verified that with arrays:
- Each domain is resolved individually
- All 3 IPs for `my.1password.com` are captured
- The loops work correctly even with strict `IFS=$'\n\t'`

## Impact
This fix ensures all 1Password domains are properly resolved and their IPs added to the firewall allowlist, allowing the 1Password CLI to function correctly in the devcontainer.