### PR TITLE
Fix Docker image name references (v1.0.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains Dev Container templates that follow the [official Dev C
 ### `liquescent-devcontainer`
 Our flagship development container template:
 
-- **Uses pre-built image** from `ghcr.io/liquescent-development/devcontainer:latest`
+- **Uses pre-built image** from `ghcr.io/liquescent-development/liquescent-devcontainer:latest`
 - **Fast startup** - no build time required
 - **Self-contained template** in `src/liquescent-devcontainer/`
 - **Ready for distribution** via OCI registry

--- a/image-sources/README.md
+++ b/image-sources/README.md
@@ -24,7 +24,7 @@ To build locally:
 
 ```bash
 cd image-sources/liquescent-devcontainer
-docker build -t ghcr.io/liquescent-development/devcontainer:latest .
+docker build -t ghcr.io/liquescent-development/liquescent-devcontainer:latest .
 ```
 
 ## Adding New Images

--- a/src/liquescent-devcontainer/.devcontainer/docker-compose.yml
+++ b/src/liquescent-devcontainer/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   devcontainer:
     # Uses pre-built image for fastest startup
     # To build locally instead, use: docker-compose -f docker-compose.local.yml up
-    image: ghcr.io/liquescent-development/devcontainer:latest
+    image: ghcr.io/liquescent-development/liquescent-devcontainer:latest
     
     # Environment variables from .env file are automatically loaded
     environment:

--- a/src/liquescent-devcontainer/devcontainer-template.json
+++ b/src/liquescent-devcontainer/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "liquescent-devcontainer",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Liquescent Development Container",
     "description": "A secure, polyglot development container with network isolation, comprehensive language support (Node.js, Go, Python, Rust, .NET), and enterprise-grade secret management via 1Password CLI.",
     "documentationURL": "https://github.com/Liquescent-Development/devcontainer",


### PR DESCRIPTION
## Summary
- Fix incorrect Docker image references in documentation
- Bump version to 1.0.2

## Changes
- Updated image references from `ghcr.io/liquescent-development/devcontainer` to `ghcr.io/liquescent-development/liquescent-devcontainer`
- This matches what the CI workflow actually creates
- Version bumped to 1.0.2 for this patch release

## Packages to Clean Up
After merging, these old packages can be deleted from GitHub Container Registry:
- `devcontainer` - Old image from previous workflow
- `templates` - Incorrect OCI artifact (should be `templates/<name>`)

Keep these:
- `liquescent-devcontainer` - Correct Docker image
- `templates/liquescent-devcontainer` - Correct OCI template artifact