### PR TITLE
Enable Python package installation by adding PyPI domains to firewall

### DIFF
--- a/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
+++ b/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
@@ -29,6 +29,10 @@ readonly BUILTIN_DOMAINS=(
     "sentry.io"
     "statsig.anthropic.com"
     "statsig.com"
+    # Python package repositories
+    "pypi.org"
+    "files.pythonhosted.org"
+    "pypi.python.org"
 )
 
 # 1Password configuration


### PR DESCRIPTION
## Summary
- Added PyPI and Python package hosting domains to the firewall allowlist
- Enables pip package installation within the devcontainer

## Changes
- Added `pypi.org`, `files.pythonhosted.org`, and `pypi.python.org` to the `BUILTIN_DOMAINS` array in the firewall initialization script

## Why
The devcontainer's network isolation was blocking access to Python package repositories, preventing developers from using `pip install` to add dependencies.

## Impact
Python developers can now install packages using pip within the secure devcontainer environment while maintaining network isolation for other domains.