### PR TITLE
Add VS Code Extension Marketplace domains to firewall

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,11 @@ This repository follows the Dev Container template specification:
    - Implements network isolation using iptables and ipset
    - Allows connections only to:
      - GitHub (dynamically fetched IP ranges)
-     - npm registry
+     - npm registry (registry.npmjs.org)
+     - Python Package Index (pypi.org, files.pythonhosted.org, pypi.python.org)
+     - VS Code Extension Marketplace (marketplace.visualstudio.com, *.gallery.vsassets.io, vscode.blob.core.windows.net)
      - Anthropic API endpoints
+     - 1Password domains (for secret management)
      - Host network (for local development)
    - Preserves Docker's internal DNS resolution
    - Verifies firewall configuration after setup

--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ See `.env.example` for all available options.
 By default, only these domains are accessible:
 - GitHub (github.com, api.github.com, etc.)
 - npm registry (registry.npmjs.org)
-- Anthropic API (api.anthropic.com)
-- Docker Hub (hub.docker.com)
+- Python Package Index (pypi.org, files.pythonhosted.org, pypi.python.org)
+- VS Code Extension Marketplace (marketplace.visualstudio.com, *.gallery.vsassets.io, vscode.blob.core.windows.net)
+- Anthropic API (api.anthropic.com, statsig.anthropic.com, sentry.io)
 - 1Password (*.1password.com, *.1password.eu, *.1password.ca, *.1passwordservices.com)
 
 #### Adding Custom Domains

--- a/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
+++ b/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
@@ -33,6 +33,11 @@ readonly BUILTIN_DOMAINS=(
     "pypi.org"
     "files.pythonhosted.org"
     "pypi.python.org"
+    # VS Code Extension Marketplace
+    "marketplace.visualstudio.com"
+    "gallery.vsassets.io"
+    "gallerycdn.vsassets.io"
+    "vscode.blob.core.windows.net"
 )
 
 # 1Password configuration


### PR DESCRIPTION
## Summary
- Adds VS Code Extension Marketplace domains to the firewall allowlist
- Updates documentation to reflect all currently allowed domains
- Enables VS Code extension installation within the devcontainer

## Changes
### Firewall Script
Added the following domains to `BUILTIN_DOMAINS` in `init-firewall.sh`:
- `marketplace.visualstudio.com` - Main marketplace API
- `gallery.vsassets.io` - Extension asset downloads
- `gallerycdn.vsassets.io` - CDN for extension assets
- `vscode.blob.core.windows.net` - Additional storage endpoint

### Documentation
- Updated README.md to list all allowed domains including Python and VS Code marketplaces
- Updated CLAUDE.md with detailed firewall domain information

## Why
VS Code extensions couldn't be installed in the devcontainer due to network isolation blocking access to the marketplace servers. This change allows developers to install extensions from within the container while maintaining security.

## Testing
After this PR is merged and the image is rebuilt:
1. Open a project in the devcontainer
2. Try installing a VS Code extension
3. Extension should install successfully