### PR TITLE
Fix VS Code extension installation timeouts by adding publisher CDN domains

### DIFF
--- a/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
+++ b/image-sources/liquescent-devcontainer/scripts/init-firewall.sh
@@ -45,6 +45,17 @@ readonly BUILTIN_DOMAINS=(
     "gallery.vsassets.io"
     "gallerycdn.vsassets.io"
     "vscode.blob.core.windows.net"
+    "www.vscode-unpkg.net"  # Fallback CDN
+    # Publisher-specific CDNs
+    "anthropic.gallerycdn.vsassets.io"
+    "streetsidesoftware.gallerycdn.vsassets.io"
+    "dbaeumer.gallerycdn.vsassets.io"
+    "ms-azuretools.gallerycdn.vsassets.io"
+    "github.gallerycdn.vsassets.io"
+    "ms-vscode.gallerycdn.vsassets.io"
+    "golang.gallerycdn.vsassets.io"
+    "rust-lang.gallerycdn.vsassets.io"
+    "ms-python.gallerycdn.vsassets.io"
 )
 
 # 1Password configuration


### PR DESCRIPTION
## Summary
- Added publisher-specific gallerycdn.vsassets.io subdomains to the firewall allowlist
- Added www.vscode-unpkg.net as a fallback CDN domain
- Fixes timeout errors when installing VS Code extensions in the devcontainer

## Test plan
- [ ] Build and test the devcontainer with the updated firewall script
- [ ] Verify VS Code extensions install without timeout errors
- [ ] Confirm network isolation remains intact for non-allowlisted domains